### PR TITLE
memory dumper for 570.133.07

### DIFF
--- a/dumper/Makefile
+++ b/dumper/Makefile
@@ -7,9 +7,16 @@ ifndef NVIDIA_DRIVER_PATH
 endif
 
 INCLUDES := -I${CUDA_PATH}/include
+
+ifdef NV_KERNEL_OPEN
+INCLUDES += -I${NVIDIA_DRIVER_PATH}/kernel-open/common/inc
+INCLUDES += -I${NVIDIA_DRIVER_PATH}/kernel-open/nvidia
+INCLUDES += -I${NVIDIA_DRIVER_PATH}/kernel-open/nvidia-uvm
+else
 INCLUDES += -I${NVIDIA_DRIVER_PATH}/kernel/common/inc
 INCLUDES += -I${NVIDIA_DRIVER_PATH}/kernel/nvidia
 INCLUDES += -I${NVIDIA_DRIVER_PATH}/kernel/nvidia-uvm
+endif
 
 all: 
 	gcc $(INCLUDES) -o dumper dumper.c -lnvidia-ml

--- a/dumper/README.md
+++ b/dumper/README.md
@@ -8,7 +8,7 @@ First, chose a supported version and set the environment variable accordingly:
 - `export NV_DRV_VERSION=535.113`
 - `export NV_DRV_VERSION=555.58.02`
 - `export NV_DRV_VERSION=560.35.03`
-- `export NV_DRV_VERSION=570.133.07`
+- `export NV_DRV_VERSION=570.133.07; export NV_KERNEL_OPEN=1` (The patch for 570.133.07 works on the open-kernel version)
 
 > If the version you want to use is not supported, you can try to apply the closest patch, but this might not work if one of the files to be patched has been modified.
 > In that case, you should patch it manually by just adding the functions and the definitions you can find in one of the patches.

--- a/dumper/README.md
+++ b/dumper/README.md
@@ -8,6 +8,7 @@ First, chose a supported version and set the environment variable accordingly:
 - `export NV_DRV_VERSION=535.113`
 - `export NV_DRV_VERSION=555.58.02`
 - `export NV_DRV_VERSION=560.35.03`
+- `export NV_DRV_VERSION=570.133.07`
 
 > If the version you want to use is not supported, you can try to apply the closest patch, but this might not work if one of the files to be patched has been modified.
 > In that case, you should patch it manually by just adding the functions and the definitions you can find in one of the patches.

--- a/dumper/patch/driver-570.133.07.patch
+++ b/dumper/patch/driver-570.133.07.patch
@@ -1,0 +1,146 @@
+diff '--color=auto' -ruN NVIDIA-Linux-x86_64-570.133.07/kernel-open/nvidia-uvm/uvm_api.h NVIDIA-Linux-x86_64-570.133.07-patched/kernel-open/nvidia-uvm/uvm_api.h
+--- NVIDIA-Linux-x86_64-570.133.07/kernel-open/nvidia-uvm/uvm_api.h	2025-03-14 13:57:33.000000000 +0100
++++ NVIDIA-Linux-x86_64-570.133.07-patched/kernel-open/nvidia-uvm/uvm_api.h	2025-04-13 17:25:47.635058754 +0200
+@@ -260,4 +260,7 @@
+ NV_STATUS uvm_api_alloc_device_p2p(UVM_ALLOC_DEVICE_P2P_PARAMS *params, struct file *filp);
+ NV_STATUS uvm_api_clear_all_access_counters(UVM_CLEAR_ALL_ACCESS_COUNTERS_PARAMS *params, struct file *filp);
+ 
++// added by zzk for dumping GPU memory
++NV_STATUS uvm_api_dump_gpu_memory(UVM_DUMP_GPU_MEMORY_PARAMS *params, struct file *filp);
++
+ #endif // __UVM_API_H__
+diff '--color=auto' -ruN NVIDIA-Linux-x86_64-570.133.07/kernel-open/nvidia-uvm/uvm.c NVIDIA-Linux-x86_64-570.133.07-patched/kernel-open/nvidia-uvm/uvm.c
+--- NVIDIA-Linux-x86_64-570.133.07/kernel-open/nvidia-uvm/uvm.c	2025-03-14 13:57:31.000000000 +0100
++++ NVIDIA-Linux-x86_64-570.133.07-patched/kernel-open/nvidia-uvm/uvm.c	2025-04-13 17:25:47.634059146 +0200
+@@ -1090,6 +1090,10 @@
+         UVM_ROUTE_CMD_STACK_INIT_CHECK(UVM_TOOLS_GET_PROCESSOR_UUID_TABLE_V2,uvm_api_tools_get_processor_uuid_table_v2);
+         UVM_ROUTE_CMD_STACK_INIT_CHECK(UVM_ALLOC_DEVICE_P2P,               uvm_api_alloc_device_p2p);
+         UVM_ROUTE_CMD_STACK_INIT_CHECK(UVM_CLEAR_ALL_ACCESS_COUNTERS,      uvm_api_clear_all_access_counters);
++
++        // added by zzk for dumping GPU memory
++        UVM_ROUTE_CMD_STACK_INIT_CHECK(UVM_DUMP_GPU_MEMORY,                uvm_api_dump_gpu_memory);
++
+     }
+ 
+     // Try the test ioctls if none of the above matched
+diff '--color=auto' -ruN NVIDIA-Linux-x86_64-570.133.07/kernel-open/nvidia-uvm/uvm_ioctl.h NVIDIA-Linux-x86_64-570.133.07-patched/kernel-open/nvidia-uvm/uvm_ioctl.h
+--- NVIDIA-Linux-x86_64-570.133.07/kernel-open/nvidia-uvm/uvm_ioctl.h	2025-03-14 13:57:27.000000000 +0100
++++ NVIDIA-Linux-x86_64-570.133.07-patched/kernel-open/nvidia-uvm/uvm_ioctl.h	2025-04-13 17:25:47.640056795 +0200
+@@ -1142,6 +1142,16 @@
+     NV_STATUS rmStatus;     // OUT
+ } UVM_IS_8_SUPPORTED_PARAMS;
+ 
++// added by zzk for dumping GPU memory
++#define UVM_DUMP_GPU_MEMORY                                           UVM_IOCTL_BASE(111)
++typedef struct
++{
++    NvProcessorUuid gpu_uuid;                      // IN
++    NvU64           base_addr  NV_ALIGN_BYTES(8);  // IN
++    NvU64           dump_size;                     // IN
++    NvU64           out_addr   NV_ALIGN_BYTES(8);  // OUT
++    NV_STATUS       rmStatus;                      // OUT
++} UVM_DUMP_GPU_MEMORY_PARAMS;
+ 
+ #ifdef __cplusplus
+ }
+diff '--color=auto' -ruN NVIDIA-Linux-x86_64-570.133.07/kernel-open/nvidia-uvm/uvm_tools.c NVIDIA-Linux-x86_64-570.133.07-patched/kernel-open/nvidia-uvm/uvm_tools.c
+--- NVIDIA-Linux-x86_64-570.133.07/kernel-open/nvidia-uvm/uvm_tools.c	2025-03-14 13:57:31.000000000 +0100
++++ NVIDIA-Linux-x86_64-570.133.07-patched/kernel-open/nvidia-uvm/uvm_tools.c	2025-04-13 17:25:47.647054052 +0200
+@@ -2860,3 +2860,83 @@
+ 
+     _uvm_tools_destroy_cache_all();
+ }
++
++// added by zzk for dumping GPU memory
++NV_STATUS 
++uvm_api_dump_gpu_memory(UVM_DUMP_GPU_MEMORY_PARAMS *params, struct file *filp)
++{
++    NvU64 base_addr = params->base_addr;
++    NvU64 dump_size = params->dump_size;
++    NvU64 out_addr = params->out_addr;
++    NvU64 offset;
++    
++    uvm_mem_t *cpu_mem = NULL;
++    uvm_mem_t *gpu_mem = NULL;
++    uvm_gpu_address_t cpu_addr;
++    uvm_gpu_address_t gpu_addr;
++    
++    uvm_gpu_t *gpu;
++    uvm_push_t push;
++    
++    NV_STATUS status = NV_OK;
++    
++    //NvU64 gpuSize = UVM_CHUNK_SIZE_MAX;
++    
++    // get GPU from the passed UUID
++    gpu = uvm_gpu_get_by_uuid(&params->gpu_uuid);
++    if (!gpu)
++        return NV_ERR_INVALID_DEVICE;
++    
++    // allocate a CPU memory buffer and map it for access
++    status = uvm_mem_alloc_sysmem_and_map_cpu_kernel(UVM_CHUNK_SIZE_MAX, current->mm, &cpu_mem);
++    if (status != NV_OK)
++        goto done;
++    status = uvm_mem_map_gpu_kernel(cpu_mem, gpu);
++    if (status != NV_OK)
++        goto done;
++    
++    // allocate a small piece of GPU memory and map it for access
++    status = uvm_mem_alloc_vidmem(UVM_CHUNK_SIZE_4K, gpu, &gpu_mem);
++    if (status != NV_OK)
++        goto done;
++    status = uvm_mem_map_gpu_kernel(gpu_mem, gpu);
++    if (status != NV_OK)
++        goto done;
++    printk("GPU mem chunk size 0x%lx\n", gpu_mem->chunk_size);
++    
++    cpu_addr = uvm_mem_gpu_address_virtual_kernel(cpu_mem, gpu);
++    gpu_addr = uvm_mem_gpu_address_physical(gpu_mem, gpu, 0, gpu_mem->chunk_size);
++    printk("GPU mem address 0x%lx\n", gpu_addr.address);
++    
++    // dump GPU memory from the base_addr for the size of dump_size
++    gpu_addr.address = base_addr;
++    offset = 0;
++    while (offset < dump_size) {
++        size_t cpy_size = min(UVM_CHUNK_SIZE_MAX, dump_size - offset);
++        
++        status = uvm_push_begin(gpu->channel_manager, UVM_CHANNEL_TYPE_GPU_TO_CPU, &push, "dumping");
++        if (status != NV_OK)
++            goto done;
++        
++        gpu->parent->ce_hal->memcopy(&push, cpu_addr, gpu_addr, cpy_size);
++        
++        status = uvm_push_end_and_wait(&push);
++        if (status != NV_OK)
++            goto done;
++        
++        // copy stuff in the buffer into userspace
++        copy_to_user((void *)out_addr, cpu_mem->kernel.cpu_addr, cpy_size);
++        gpu_addr.address += cpy_size;
++        out_addr += cpy_size;
++        offset += cpy_size;
++    }
++    
++done:
++    if (cpu_mem)
++        uvm_mem_free(cpu_mem);
++    if (gpu_mem)
++        uvm_mem_free(gpu_mem);
++    
++    return status;
++}
++
+diff '--color=auto' -ruN NVIDIA-Linux-x86_64-570.133.07/kernel-open/nvidia-uvm/uvm_tools.h NVIDIA-Linux-x86_64-570.133.07-patched/kernel-open/nvidia-uvm/uvm_tools.h
+--- NVIDIA-Linux-x86_64-570.133.07/kernel-open/nvidia-uvm/uvm_tools.h	2025-03-14 13:57:31.000000000 +0100
++++ NVIDIA-Linux-x86_64-570.133.07-patched/kernel-open/nvidia-uvm/uvm_tools.h	2025-04-13 17:25:47.647054052 +0200
+@@ -43,6 +43,10 @@
+                                                     struct file *filp);
+ NV_STATUS uvm_api_tools_flush_events(UVM_TOOLS_FLUSH_EVENTS_PARAMS *params, struct file *filp);
+ 
++// added by zzk for dumping GPU memory
++NV_STATUS uvm_api_dump_gpu_memory(UVM_DUMP_GPU_MEMORY_PARAMS *params, struct file *filp);
++
++
+ static UvmEventFatalReason uvm_tools_status_to_fatal_fault_reason(NV_STATUS status)
+ {
+     switch (status) {


### PR DESCRIPTION
Hello,
This is the patch file for 570.133.07. The patch is applied to the open kernel because it is the NVIDIA-recommended driver for newer GPUs (https://developer.nvidia.com/blog/nvidia-transitions-fully-towards-open-source-gpu-kernel-modules/) 