### PR TITLE
Enable GPU memory dumping for MIG instances

### DIFF
--- a/dumper/Makefile
+++ b/dumper/Makefile
@@ -7,9 +7,16 @@ ifndef NVIDIA_DRIVER_PATH
 endif
 
 INCLUDES := -I${CUDA_PATH}/include
+
+ifdef NV_KERNEL_OPEN
+INCLUDES += -I${NVIDIA_DRIVER_PATH}/kernel-open/common/inc
+INCLUDES += -I${NVIDIA_DRIVER_PATH}/kernel-open/nvidia
+INCLUDES += -I${NVIDIA_DRIVER_PATH}/kernel-open/nvidia-uvm
+else
 INCLUDES += -I${NVIDIA_DRIVER_PATH}/kernel/common/inc
 INCLUDES += -I${NVIDIA_DRIVER_PATH}/kernel/nvidia
 INCLUDES += -I${NVIDIA_DRIVER_PATH}/kernel/nvidia-uvm
+endif
 
 all: 
 	gcc $(INCLUDES) -o dumper dumper.c -lnvidia-ml

--- a/dumper/README.md
+++ b/dumper/README.md
@@ -8,7 +8,7 @@ First, chose a supported version and set the environment variable accordingly:
 - `export NV_DRV_VERSION=535.113`
 - `export NV_DRV_VERSION=555.58.02`
 - `export NV_DRV_VERSION=560.35.03`
-- `export NV_DRV_VERSION=570.133.07`
+- `export NV_DRV_VERSION=570.133.07; export NV_KERNEL_OPEN=1` (The patch for 570.133.07 works on the open-kernel version)
 
 > If the version you want to use is not supported, you can try to apply the closest patch, but this might not work if one of the files to be patched has been modified.
 > In that case, you should patch it manually by just adding the functions and the definitions you can find in one of the patches.

--- a/dumper/README.md
+++ b/dumper/README.md
@@ -8,6 +8,7 @@ First, chose a supported version and set the environment variable accordingly:
 - `export NV_DRV_VERSION=535.113`
 - `export NV_DRV_VERSION=555.58.02`
 - `export NV_DRV_VERSION=560.35.03`
+- `export NV_DRV_VERSION=570.133.07`
 
 > If the version you want to use is not supported, you can try to apply the closest patch, but this might not work if one of the files to be patched has been modified.
 > In that case, you should patch it manually by just adding the functions and the definitions you can find in one of the patches.

--- a/dumper/README.md
+++ b/dumper/README.md
@@ -80,3 +80,5 @@ Now, you can use our GPU memory dumper to dump GPU memory. For example, the foll
 - -b specifies the number of bytes to dump. 
 
 - -o specifies the file to which the GPU memory is dumped. 
+
+- -g optionally specify the active GPU instance (GI). The index depends on the order in which the instances were launched (0 for the first, 1 for the second, etc.). Defaults to 0 if only one instance is active.

--- a/dumper/dumper.c
+++ b/dumper/dumper.c
@@ -5,10 +5,66 @@
 #include <sys/ioctl.h>
 #include <sys/mman.h>
 #include <unistd.h>
+#include <stdint.h>
+#include <stdbool.h>
 
 #include <nvml.h>
 #include <nvtypes.h>
 #include <uvm_linux_ioctl.h>
+
+// static int uvm_hex_to_digit(char c) {
+//     if (c >= '0' && c <= '9') return c - '0';
+//     if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+//     return -1;
+// }
+// 
+// bool uvm_uuid_from_string(uint8_t *uuid, const char *str) {
+//     if (!uuid || !str) return false;
+// 
+//     int byte_idx = 0;
+//     int char_idx = 0;
+//     int digit1, digit2;
+// 
+//     while (byte_idx < 36) {
+//         if (byte_idx == 4 || byte_idx == 6 || byte_idx == 8 || byte_idx == 10) {
+//             if (str[char_idx] != '-') return false;
+//             char_idx++;
+//         }
+// 
+//         digit1 = uvm_hex_to_digit(str[char_idx++]);
+//         if (digit1 < 0) return false;
+// 
+//         digit2 = uvm_hex_to_digit(str[char_idx++]);
+//         if (digit2 < 0) return false;
+// 
+//         uuid[byte_idx++] = (uint8_t)((digit1 << 4) | digit2);
+//     }
+// }
+// 
+// char uvm_digit_to_hex(unsigned value)
+// {
+//     if (value >= 10)
+//         return value - 10 + 'a';
+//     else
+//         return value + '0';
+// }
+// 
+// void uvm_uuid_string(char *buffer, uint8_t *uuid)
+// {
+//     char *str = buffer;
+//     unsigned i;
+//     unsigned dashMask = 1 << 4 | 1 << 6 | 1 << 8 | 1 << 10;
+// 
+//     for (i = 0; i < 16; i++) {
+//         *str++ = uvm_digit_to_hex(uuid[i] >> 4);
+//         *str++ = uvm_digit_to_hex(uuid[i] & 0xF);
+// 
+//         if (dashMask & (1 << (i + 1)))
+//             *str++ = '-';
+//     }
+// 
+//     *str = 0;
+// }
 
 int 
 main(int argc, char *argv[])
@@ -21,12 +77,16 @@ main(int argc, char *argv[])
   int dump_fd = -1;
   unsigned long dump_size = 0;
   unsigned long base_addr = 0;
+  int mig_id = -1;
+  unsigned int gpu_instance_id = 0;
   char *dump_file = NULL;
   void *dump_ptr = NULL;
   
   nvmlReturn_t nvml_ret;
   nvmlDevice_t nvml_dev;
-  char nvml_uuid[NVML_DEVICE_UUID_BUFFER_SIZE];
+  nvmlDevice_t nvml_dev_mig;
+
+  char nvml_uuid[NVML_DEVICE_UUID_V2_BUFFER_SIZE];
   const char *uuid_str = NULL;
   
   UVM_INITIALIZE_PARAMS       init_params = {0};
@@ -34,7 +94,7 @@ main(int argc, char *argv[])
   UVM_DUMP_GPU_MEMORY_PARAMS  dump_params = {0};
   
   // parse arguments
-  while ((opt = getopt(argc, argv, "b:d:o:s:")) != -1) {
+  while ((opt = getopt(argc, argv, "b:d:o:s:m:")) != -1) {
     printf("%s\n", optarg);
     switch (opt) {
       case 'b':
@@ -49,6 +109,9 @@ main(int argc, char *argv[])
       case 's':
         base_addr = strtoul(optarg, NULL, 0);
         break;
+      case 'm':
+        mig_id = atoi(optarg);
+        break;
     }
   }  
   
@@ -56,6 +119,8 @@ main(int argc, char *argv[])
     printf("Usage: %s [-d <dev>] [-s <addr>] -b <bytes> -o <file>\n", argv[0]);
     goto cleanup;
   }
+
+  printf("[!] base_addr: 0x%lx, dump_size: 0x%lx\n", base_addr, dump_size);
   
   // get device and its UUID
   nvml_ret = nvmlInit();
@@ -70,12 +135,28 @@ main(int argc, char *argv[])
     goto cleanup;
   }
   
+  // It doesn't matter because the MIG UUID is different than the GPU UUID
+  // if (mig_id != -1) {
+  //     nvml_ret = nvmlDeviceGetMigDeviceHandleByIndex(nvml_dev, mig_id, &nvml_dev_mig);
+  //     if (nvml_ret != NVML_SUCCESS) {
+  //       printf("cannot get mig device: %s\n", nvmlErrorString(nvml_ret));
+  //       goto cleanup;
+  //     }
+  //     nvml_ret = nvmlDeviceGetUUID(nvml_dev_mig, nvml_uuid, sizeof(nvml_uuid));
+  //     if (nvml_ret != NVML_SUCCESS) {
+  //       printf("cannot get mig device UUID: %s\n", nvmlErrorString(nvml_ret));
+  //       goto cleanup;
+  //     }
+  // }
   nvml_ret = nvmlDeviceGetUUID(nvml_dev, nvml_uuid, sizeof(nvml_uuid));
   if (nvml_ret != NVML_SUCCESS) {
     printf("cannot get device UUID: %s\n", nvmlErrorString(nvml_ret));
     goto cleanup;
   }
+  dump_params.child_id = -1;
   
+  printf("UUID: %s\n", nvml_uuid);
+
   uuid_str = nvml_uuid + 4;
   for (i = 0; i < 16; ++i) {
     sscanf(uuid_str, "%2hhx", &reg_params.gpu_uuid.uuid[i]);
@@ -83,6 +164,7 @@ main(int argc, char *argv[])
     if (*uuid_str == '-')
       ++uuid_str;
   }
+
     
   uvm_dev_fd = open("/dev/nvidia-uvm", O_RDWR);
   if (uvm_dev_fd < 0) {
@@ -119,6 +201,7 @@ main(int argc, char *argv[])
   }
   
   memcpy(&(dump_params.gpu_uuid), &(reg_params.gpu_uuid), 16);
+  dump_params.child_id = mig_id;
   dump_params.base_addr = base_addr;
   dump_params.dump_size = dump_size;
   dump_params.out_addr = (unsigned long)dump_ptr;

--- a/dumper/patch/driver-570.133.07.patch
+++ b/dumper/patch/driver-570.133.07.patch
@@ -1,6 +1,6 @@
 diff '--color=auto' -ruN NVIDIA-Linux-x86_64-570.133.07/kernel-open/nvidia-uvm/uvm_api.h NVIDIA-Linux-x86_64-570.133.07-patched/kernel-open/nvidia-uvm/uvm_api.h
 --- NVIDIA-Linux-x86_64-570.133.07/kernel-open/nvidia-uvm/uvm_api.h	2025-03-14 13:57:33.000000000 +0100
-+++ NVIDIA-Linux-x86_64-570.133.07-patched/kernel-open/nvidia-uvm/uvm_api.h	2025-04-13 17:25:47.635058754 +0200
++++ NVIDIA-Linux-x86_64-570.133.07-patched/kernel-open/nvidia-uvm/uvm_api.h	2025-04-14 18:22:52.985707593 +0200
 @@ -260,4 +260,7 @@
  NV_STATUS uvm_api_alloc_device_p2p(UVM_ALLOC_DEVICE_P2P_PARAMS *params, struct file *filp);
  NV_STATUS uvm_api_clear_all_access_counters(UVM_CLEAR_ALL_ACCESS_COUNTERS_PARAMS *params, struct file *filp);
@@ -11,7 +11,7 @@ diff '--color=auto' -ruN NVIDIA-Linux-x86_64-570.133.07/kernel-open/nvidia-uvm/u
  #endif // __UVM_API_H__
 diff '--color=auto' -ruN NVIDIA-Linux-x86_64-570.133.07/kernel-open/nvidia-uvm/uvm.c NVIDIA-Linux-x86_64-570.133.07-patched/kernel-open/nvidia-uvm/uvm.c
 --- NVIDIA-Linux-x86_64-570.133.07/kernel-open/nvidia-uvm/uvm.c	2025-03-14 13:57:31.000000000 +0100
-+++ NVIDIA-Linux-x86_64-570.133.07-patched/kernel-open/nvidia-uvm/uvm.c	2025-04-13 17:25:47.634059146 +0200
++++ NVIDIA-Linux-x86_64-570.133.07-patched/kernel-open/nvidia-uvm/uvm.c	2025-04-14 18:22:52.984707604 +0200
 @@ -1090,6 +1090,10 @@
          UVM_ROUTE_CMD_STACK_INIT_CHECK(UVM_TOOLS_GET_PROCESSOR_UUID_TABLE_V2,uvm_api_tools_get_processor_uuid_table_v2);
          UVM_ROUTE_CMD_STACK_INIT_CHECK(UVM_ALLOC_DEVICE_P2P,               uvm_api_alloc_device_p2p);
@@ -23,10 +23,30 @@ diff '--color=auto' -ruN NVIDIA-Linux-x86_64-570.133.07/kernel-open/nvidia-uvm/u
      }
  
      // Try the test ioctls if none of the above matched
+diff '--color=auto' -ruN NVIDIA-Linux-x86_64-570.133.07/kernel-open/nvidia-uvm/uvm_gpu.c NVIDIA-Linux-x86_64-570.133.07-patched/kernel-open/nvidia-uvm/uvm_gpu.c
+--- NVIDIA-Linux-x86_64-570.133.07/kernel-open/nvidia-uvm/uvm_gpu.c	2025-03-14 13:57:31.000000000 +0100
++++ NVIDIA-Linux-x86_64-570.133.07-patched/kernel-open/nvidia-uvm/uvm_gpu.c	2025-04-14 18:22:52.988707562 +0200
+@@ -1512,6 +1512,8 @@
+              parent_uuid_buffer,
+              gi_uuid_buffer);
+ 
++    printk(KERN_INFO "init_gpu gpu->name: %s\n", gpu->name);
++
+     // Initialize the per-GPU procfs dirs as early as possible so that other
+     // parts of the driver can add files in them as part of their per-GPU init.
+     status = init_procfs_dirs(gpu);
+@@ -2881,6 +2883,7 @@
+     if (status != NV_OK)
+         goto error_unregister;
+ 
++
+     if (parent_gpu != NULL) {
+         // If the UUID has been seen before, and if SMC is enabled, then check
+         // if this specific partition has been seen previously. The UUID-based
 diff '--color=auto' -ruN NVIDIA-Linux-x86_64-570.133.07/kernel-open/nvidia-uvm/uvm_ioctl.h NVIDIA-Linux-x86_64-570.133.07-patched/kernel-open/nvidia-uvm/uvm_ioctl.h
 --- NVIDIA-Linux-x86_64-570.133.07/kernel-open/nvidia-uvm/uvm_ioctl.h	2025-03-14 13:57:27.000000000 +0100
-+++ NVIDIA-Linux-x86_64-570.133.07-patched/kernel-open/nvidia-uvm/uvm_ioctl.h	2025-04-13 17:25:47.640056795 +0200
-@@ -1142,6 +1142,16 @@
++++ NVIDIA-Linux-x86_64-570.133.07-patched/kernel-open/nvidia-uvm/uvm_ioctl.h	2025-04-14 18:22:52.991707531 +0200
+@@ -1142,6 +1142,17 @@
      NV_STATUS rmStatus;     // OUT
  } UVM_IS_8_SUPPORTED_PARAMS;
  
@@ -35,6 +55,7 @@ diff '--color=auto' -ruN NVIDIA-Linux-x86_64-570.133.07/kernel-open/nvidia-uvm/u
 +typedef struct
 +{
 +    NvProcessorUuid gpu_uuid;                      // IN
++    NvS32           child_id;                      // IN
 +    NvU64           base_addr  NV_ALIGN_BYTES(8);  // IN
 +    NvU64           dump_size;                     // IN
 +    NvU64           out_addr   NV_ALIGN_BYTES(8);  // OUT
@@ -45,8 +66,8 @@ diff '--color=auto' -ruN NVIDIA-Linux-x86_64-570.133.07/kernel-open/nvidia-uvm/u
  }
 diff '--color=auto' -ruN NVIDIA-Linux-x86_64-570.133.07/kernel-open/nvidia-uvm/uvm_tools.c NVIDIA-Linux-x86_64-570.133.07-patched/kernel-open/nvidia-uvm/uvm_tools.c
 --- NVIDIA-Linux-x86_64-570.133.07/kernel-open/nvidia-uvm/uvm_tools.c	2025-03-14 13:57:31.000000000 +0100
-+++ NVIDIA-Linux-x86_64-570.133.07-patched/kernel-open/nvidia-uvm/uvm_tools.c	2025-04-13 17:25:47.647054052 +0200
-@@ -2860,3 +2860,83 @@
++++ NVIDIA-Linux-x86_64-570.133.07-patched/kernel-open/nvidia-uvm/uvm_tools.c	2025-04-14 18:22:52.998707457 +0200
+@@ -2860,3 +2860,105 @@
  
      _uvm_tools_destroy_cache_all();
  }
@@ -64,18 +85,38 @@ diff '--color=auto' -ruN NVIDIA-Linux-x86_64-570.133.07/kernel-open/nvidia-uvm/u
 +    uvm_mem_t *gpu_mem = NULL;
 +    uvm_gpu_address_t cpu_addr;
 +    uvm_gpu_address_t gpu_addr;
++    char gpu_uuid_buffer[UVM_UUID_STRING_LENGTH];
 +    
 +    uvm_gpu_t *gpu;
++    uvm_parent_gpu_t *parent_gpu;
 +    uvm_push_t push;
 +    
 +    NV_STATUS status = NV_OK;
 +    
 +    //NvU64 gpuSize = UVM_CHUNK_SIZE_MAX;
 +    
-+    // get GPU from the passed UUID
-+    gpu = uvm_gpu_get_by_uuid(&params->gpu_uuid);
-+    if (!gpu)
++    // Added by meowmeowxw
++    // There are two scenarios:
++    // 1. MIG Disabled: The parent and child GPU UUID are the same
++    // 2. MIG Enabled:
++    //    - The parent UUID is the physical GPU UUID (GPU-xxxx...)
++    //    - The child UUID is the GPU instance UUID (GI-xxxx...), which is different from the MIG UUID (MIG-xxxx...)
++    // Using this method (first fetch the parent, then the child), it is possible to dump memory for MIG devices.
++    uvm_uuid_string(gpu_uuid_buffer, &params->gpu_uuid);
++    parent_gpu = uvm_parent_gpu_get_by_uuid(&params->gpu_uuid);
++    if (!parent_gpu) {
++        printk(KERN_ERR "uvm_api_dump_gpu_memory parent gpu not found with uuid: %s\n", gpu_uuid_buffer);
 +        return NV_ERR_INVALID_DEVICE;
++
++    }
++    if (test_bit(params->child_id, parent_gpu->valid_gpus)) {
++        gpu = parent_gpu->gpus[params->child_id];
++        uvm_uuid_string(gpu_uuid_buffer, &gpu->uuid);
++        printk(KERN_INFO "uvm_api_dump_gpu_memory child gpu %d uuid: %s\n", params->child_id, gpu_uuid_buffer);
++    } else {
++        printk(KERN_ERR "uvm_api_dump_gpu_memory child gpu %d not found\n", params->child_id);
++        return NV_ERR_INVALID_DEVICE;
++    }
 +    
 +    // allocate a CPU memory buffer and map it for access
 +    status = uvm_mem_alloc_sysmem_and_map_cpu_kernel(UVM_CHUNK_SIZE_MAX, current->mm, &cpu_mem);
@@ -92,14 +133,16 @@ diff '--color=auto' -ruN NVIDIA-Linux-x86_64-570.133.07/kernel-open/nvidia-uvm/u
 +    status = uvm_mem_map_gpu_kernel(gpu_mem, gpu);
 +    if (status != NV_OK)
 +        goto done;
-+    printk("GPU mem chunk size 0x%lx\n", gpu_mem->chunk_size);
++    printk("GPU mem chunk size 0x%llx\n", gpu_mem->chunk_size);
 +    
 +    cpu_addr = uvm_mem_gpu_address_virtual_kernel(cpu_mem, gpu);
 +    gpu_addr = uvm_mem_gpu_address_physical(gpu_mem, gpu, 0, gpu_mem->chunk_size);
-+    printk("GPU mem address 0x%lx\n", gpu_addr.address);
++    printk("GPU mem address 0x%llx\n", gpu_addr.address);
 +    
 +    // dump GPU memory from the base_addr for the size of dump_size
 +    gpu_addr.address = base_addr;
++    printk(KERN_INFO "uvm_api_dump_gpu_memory instance phys start: 0x%llx, instance size: 0x%llx, gpu_addr.address: 0x%llx\n", \
++            gpu->mem_info.phys_start, gpu->mem_info.size, gpu_addr.address);
 +    offset = 0;
 +    while (offset < dump_size) {
 +        size_t cpy_size = min(UVM_CHUNK_SIZE_MAX, dump_size - offset);
@@ -132,7 +175,7 @@ diff '--color=auto' -ruN NVIDIA-Linux-x86_64-570.133.07/kernel-open/nvidia-uvm/u
 +
 diff '--color=auto' -ruN NVIDIA-Linux-x86_64-570.133.07/kernel-open/nvidia-uvm/uvm_tools.h NVIDIA-Linux-x86_64-570.133.07-patched/kernel-open/nvidia-uvm/uvm_tools.h
 --- NVIDIA-Linux-x86_64-570.133.07/kernel-open/nvidia-uvm/uvm_tools.h	2025-03-14 13:57:31.000000000 +0100
-+++ NVIDIA-Linux-x86_64-570.133.07-patched/kernel-open/nvidia-uvm/uvm_tools.h	2025-04-13 17:25:47.647054052 +0200
++++ NVIDIA-Linux-x86_64-570.133.07-patched/kernel-open/nvidia-uvm/uvm_tools.h	2025-04-14 18:22:52.998707457 +0200
 @@ -43,6 +43,10 @@
                                                      struct file *filp);
  NV_STATUS uvm_api_tools_flush_events(UVM_TOOLS_FLUSH_EVENTS_PARAMS *params, struct file *filp);

--- a/dumper/patch/driver-570.133.07.patch
+++ b/dumper/patch/driver-570.133.07.patch
@@ -1,0 +1,146 @@
+diff '--color=auto' -ruN NVIDIA-Linux-x86_64-570.133.07/kernel-open/nvidia-uvm/uvm_api.h NVIDIA-Linux-x86_64-570.133.07-patched/kernel-open/nvidia-uvm/uvm_api.h
+--- NVIDIA-Linux-x86_64-570.133.07/kernel-open/nvidia-uvm/uvm_api.h	2025-03-14 13:57:33.000000000 +0100
++++ NVIDIA-Linux-x86_64-570.133.07-patched/kernel-open/nvidia-uvm/uvm_api.h	2025-04-13 17:25:47.635058754 +0200
+@@ -260,4 +260,7 @@
+ NV_STATUS uvm_api_alloc_device_p2p(UVM_ALLOC_DEVICE_P2P_PARAMS *params, struct file *filp);
+ NV_STATUS uvm_api_clear_all_access_counters(UVM_CLEAR_ALL_ACCESS_COUNTERS_PARAMS *params, struct file *filp);
+ 
++// added by zzk for dumping GPU memory
++NV_STATUS uvm_api_dump_gpu_memory(UVM_DUMP_GPU_MEMORY_PARAMS *params, struct file *filp);
++
+ #endif // __UVM_API_H__
+diff '--color=auto' -ruN NVIDIA-Linux-x86_64-570.133.07/kernel-open/nvidia-uvm/uvm.c NVIDIA-Linux-x86_64-570.133.07-patched/kernel-open/nvidia-uvm/uvm.c
+--- NVIDIA-Linux-x86_64-570.133.07/kernel-open/nvidia-uvm/uvm.c	2025-03-14 13:57:31.000000000 +0100
++++ NVIDIA-Linux-x86_64-570.133.07-patched/kernel-open/nvidia-uvm/uvm.c	2025-04-13 17:25:47.634059146 +0200
+@@ -1090,6 +1090,10 @@
+         UVM_ROUTE_CMD_STACK_INIT_CHECK(UVM_TOOLS_GET_PROCESSOR_UUID_TABLE_V2,uvm_api_tools_get_processor_uuid_table_v2);
+         UVM_ROUTE_CMD_STACK_INIT_CHECK(UVM_ALLOC_DEVICE_P2P,               uvm_api_alloc_device_p2p);
+         UVM_ROUTE_CMD_STACK_INIT_CHECK(UVM_CLEAR_ALL_ACCESS_COUNTERS,      uvm_api_clear_all_access_counters);
++
++        // added by zzk for dumping GPU memory
++        UVM_ROUTE_CMD_STACK_INIT_CHECK(UVM_DUMP_GPU_MEMORY,                uvm_api_dump_gpu_memory);
++
+     }
+ 
+     // Try the test ioctls if none of the above matched
+diff '--color=auto' -ruN NVIDIA-Linux-x86_64-570.133.07/kernel-open/nvidia-uvm/uvm_ioctl.h NVIDIA-Linux-x86_64-570.133.07-patched/kernel-open/nvidia-uvm/uvm_ioctl.h
+--- NVIDIA-Linux-x86_64-570.133.07/kernel-open/nvidia-uvm/uvm_ioctl.h	2025-03-14 13:57:27.000000000 +0100
++++ NVIDIA-Linux-x86_64-570.133.07-patched/kernel-open/nvidia-uvm/uvm_ioctl.h	2025-04-13 17:25:47.640056795 +0200
+@@ -1142,6 +1142,16 @@
+     NV_STATUS rmStatus;     // OUT
+ } UVM_IS_8_SUPPORTED_PARAMS;
+ 
++// added by zzk for dumping GPU memory
++#define UVM_DUMP_GPU_MEMORY                                           UVM_IOCTL_BASE(111)
++typedef struct
++{
++    NvProcessorUuid gpu_uuid;                      // IN
++    NvU64           base_addr  NV_ALIGN_BYTES(8);  // IN
++    NvU64           dump_size;                     // IN
++    NvU64           out_addr   NV_ALIGN_BYTES(8);  // OUT
++    NV_STATUS       rmStatus;                      // OUT
++} UVM_DUMP_GPU_MEMORY_PARAMS;
+ 
+ #ifdef __cplusplus
+ }
+diff '--color=auto' -ruN NVIDIA-Linux-x86_64-570.133.07/kernel-open/nvidia-uvm/uvm_tools.c NVIDIA-Linux-x86_64-570.133.07-patched/kernel-open/nvidia-uvm/uvm_tools.c
+--- NVIDIA-Linux-x86_64-570.133.07/kernel-open/nvidia-uvm/uvm_tools.c	2025-03-14 13:57:31.000000000 +0100
++++ NVIDIA-Linux-x86_64-570.133.07-patched/kernel-open/nvidia-uvm/uvm_tools.c	2025-04-13 17:25:47.647054052 +0200
+@@ -2860,3 +2860,83 @@
+ 
+     _uvm_tools_destroy_cache_all();
+ }
++
++// added by zzk for dumping GPU memory
++NV_STATUS 
++uvm_api_dump_gpu_memory(UVM_DUMP_GPU_MEMORY_PARAMS *params, struct file *filp)
++{
++    NvU64 base_addr = params->base_addr;
++    NvU64 dump_size = params->dump_size;
++    NvU64 out_addr = params->out_addr;
++    NvU64 offset;
++    
++    uvm_mem_t *cpu_mem = NULL;
++    uvm_mem_t *gpu_mem = NULL;
++    uvm_gpu_address_t cpu_addr;
++    uvm_gpu_address_t gpu_addr;
++    
++    uvm_gpu_t *gpu;
++    uvm_push_t push;
++    
++    NV_STATUS status = NV_OK;
++    
++    //NvU64 gpuSize = UVM_CHUNK_SIZE_MAX;
++    
++    // get GPU from the passed UUID
++    gpu = uvm_gpu_get_by_uuid(&params->gpu_uuid);
++    if (!gpu)
++        return NV_ERR_INVALID_DEVICE;
++    
++    // allocate a CPU memory buffer and map it for access
++    status = uvm_mem_alloc_sysmem_and_map_cpu_kernel(UVM_CHUNK_SIZE_MAX, current->mm, &cpu_mem);
++    if (status != NV_OK)
++        goto done;
++    status = uvm_mem_map_gpu_kernel(cpu_mem, gpu);
++    if (status != NV_OK)
++        goto done;
++    
++    // allocate a small piece of GPU memory and map it for access
++    status = uvm_mem_alloc_vidmem(UVM_CHUNK_SIZE_4K, gpu, &gpu_mem);
++    if (status != NV_OK)
++        goto done;
++    status = uvm_mem_map_gpu_kernel(gpu_mem, gpu);
++    if (status != NV_OK)
++        goto done;
++    printk("GPU mem chunk size 0x%lx\n", gpu_mem->chunk_size);
++    
++    cpu_addr = uvm_mem_gpu_address_virtual_kernel(cpu_mem, gpu);
++    gpu_addr = uvm_mem_gpu_address_physical(gpu_mem, gpu, 0, gpu_mem->chunk_size);
++    printk("GPU mem address 0x%lx\n", gpu_addr.address);
++    
++    // dump GPU memory from the base_addr for the size of dump_size
++    gpu_addr.address = base_addr;
++    offset = 0;
++    while (offset < dump_size) {
++        size_t cpy_size = min(UVM_CHUNK_SIZE_MAX, dump_size - offset);
++        
++        status = uvm_push_begin(gpu->channel_manager, UVM_CHANNEL_TYPE_GPU_TO_CPU, &push, "dumping");
++        if (status != NV_OK)
++            goto done;
++        
++        gpu->parent->ce_hal->memcopy(&push, cpu_addr, gpu_addr, cpy_size);
++        
++        status = uvm_push_end_and_wait(&push);
++        if (status != NV_OK)
++            goto done;
++        
++        // copy stuff in the buffer into userspace
++        copy_to_user((void *)out_addr, cpu_mem->kernel.cpu_addr, cpy_size);
++        gpu_addr.address += cpy_size;
++        out_addr += cpy_size;
++        offset += cpy_size;
++    }
++    
++done:
++    if (cpu_mem)
++        uvm_mem_free(cpu_mem);
++    if (gpu_mem)
++        uvm_mem_free(gpu_mem);
++    
++    return status;
++}
++
+diff '--color=auto' -ruN NVIDIA-Linux-x86_64-570.133.07/kernel-open/nvidia-uvm/uvm_tools.h NVIDIA-Linux-x86_64-570.133.07-patched/kernel-open/nvidia-uvm/uvm_tools.h
+--- NVIDIA-Linux-x86_64-570.133.07/kernel-open/nvidia-uvm/uvm_tools.h	2025-03-14 13:57:31.000000000 +0100
++++ NVIDIA-Linux-x86_64-570.133.07-patched/kernel-open/nvidia-uvm/uvm_tools.h	2025-04-13 17:25:47.647054052 +0200
+@@ -43,6 +43,10 @@
+                                                     struct file *filp);
+ NV_STATUS uvm_api_tools_flush_events(UVM_TOOLS_FLUSH_EVENTS_PARAMS *params, struct file *filp);
+ 
++// added by zzk for dumping GPU memory
++NV_STATUS uvm_api_dump_gpu_memory(UVM_DUMP_GPU_MEMORY_PARAMS *params, struct file *filp);
++
++
+ static UvmEventFatalReason uvm_tools_status_to_fatal_fault_reason(NV_STATUS status)
+ {
+     switch (status) {


### PR DESCRIPTION
It is based on 570.133.07, so it is simlar to https://github.com/0x5ec1ab/gpu-tlb/pull/9 . 

I couldn't find a way to enumerate the GPU UUIDs for MIG instances. It seems that the UUID obtained using the combination of:

```
nvmlDeviceGetMigDeviceHandleByIndex() + nvmlDeviceGetUUID()
```

(which results in a MIG-xxxxx... style UUID) is not the same as the GPU Instance UUID. The latter is the UUID required by uvm_gpu_get_by_uuid() to retrieve a uvm_gpu_t instance.

To work around this, I modified the kernel code to first call uvm_parent_gpu_get_by_uuid() and then access the corresponding child GPU instance. If multiple child instances are active simultaneously, you can pass the -g option to the dumper to specify the index of the desired instance.

This implementation works with both MIG-enabled and MIG-disabled configurations.