### PR TITLE
Fix extractor to dump page tables when the dump offset is not 0

### DIFF
--- a/extractor/Makefile
+++ b/extractor/Makefile
@@ -1,6 +1,6 @@
 CXX = g++ 
 CXXFLAGS = -g -std=c++11
-SRCS = main.cpp mem-dump.cpp page-tab.cpp page-dir.cpp page-map.cpp page.cpp
+SRCS = main.cpp mem-dump.cpp page-tab.cpp page-dir.cpp page-map.cpp page.cpp common.cpp
 OBJS = $(SRCS:.cpp=.o)
 BIN = extractor
 

--- a/extractor/common.cpp
+++ b/extractor/common.cpp
@@ -1,0 +1,3 @@
+#include "common.h"
+
+std::uint64_t vgpuOffset = 0x0;

--- a/extractor/common.h
+++ b/extractor/common.h
@@ -1,0 +1,8 @@
+#ifndef _COMMON_H_
+#define _COMMON_H_
+
+#include <cstdint>
+
+extern std::uint64_t vgpuOffset;
+
+#endif

--- a/extractor/main.cpp
+++ b/extractor/main.cpp
@@ -11,6 +11,7 @@
 #include "page-dir.h"
 #include "page-tab.h"
 #include "page.h"
+#include "common.h"
 
 /*******************************************************************************
  *
@@ -18,13 +19,15 @@
 int 
 main(int argc, char *argv[])
 {
-  if (argc < 2 || argc > 3) {
-    std::cout << "Usage: " << argv[0] << " <dump> [physical‑offset]\n";
+  if (argc < 2 || argc > 4) {
+    std::cout << "Usage: " << argv[0] << " <dump> [physical‑offset] [vgpu-offset]\n";
     return -1;
   }
   std::uint64_t physOffset = 0;
   if (argc == 3)
     physOffset = std::strtoull(argv[2], nullptr, 0);
+  if (argc == 4)
+    vgpuOffset = std::strtoull(argv[3], nullptr, 0);
 
   MemDump dump(argv[1], physOffset);
 

--- a/extractor/main.cpp
+++ b/extractor/main.cpp
@@ -3,6 +3,7 @@
 #include <iostream>
 #include <string>
 #include <vector>
+#include <cstdlib>
 
 #include "mem-dump.h"
 #include "trans.h"
@@ -17,17 +18,21 @@
 int 
 main(int argc, char *argv[])
 {
-  if (argc != 2) {
-    std::cout << argv[0] << " <dump>\n";
+  if (argc < 2 || argc > 3) {
+    std::cout << "Usage: " << argv[0] << " <dump> [physical‑offset]\n";
     return -1;
   }
-  
-  MemDump dump(argv[1]);
+  std::uint64_t physOffset = 0;
+  if (argc == 3)
+    physOffset = std::strtoull(argv[2], nullptr, 0);
+
+  MemDump dump(argv[1], physOffset);
+
   std::uint64_t chunkNum = dump.getChunkNum();
-  
+
   std::vector<Trans *> pageMaps;
   for (std::uint64_t i = 0; i < chunkNum; ++i) {
-    std::uint64_t phyAddr = i * CHUNK_SIZE;
+    std::uint64_t phyAddr = physOffset + i * CHUNK_SIZE;
     Trans *topPtr = new PageMap(dump, phyAddr, PD3);
     bool ok = topPtr->constructTrans();
     if (!ok)
@@ -35,7 +40,7 @@ main(int argc, char *argv[])
     else
       pageMaps.push_back(topPtr);
   }
-  
+
   for (auto topPtr : pageMaps)
     topPtr->printTrans(0);
 }

--- a/extractor/mem-dump.cpp
+++ b/extractor/mem-dump.cpp
@@ -3,7 +3,8 @@
 /*******************************************************************************
  *
  ******************************************************************************/
-MemDump::MemDump(const char *fileName)
+MemDump::MemDump(const char *fileName, std::uint64_t physOffset)
+: mPhysOffset(physOffset)
 {
   mFd = open(fileName, O_RDONLY);
   if (mFd < 0)
@@ -39,13 +40,15 @@ MemDump::getChunkNum()
 /*******************************************************************************
  *
  ******************************************************************************/
-std::uint8_t 
-MemDump::getByte(std::uint64_t offset)
+std::uint8_t
+MemDump::getByte(std::uint64_t physAddress)
 {
-  if (offset < mLen)
-    return *((std::uint8_t *)mBasePtr + offset);
-  else
+  if (physAddress < mPhysOffset)
     return 0;
+  std::uint64_t fileOff = physAddress - mPhysOffset;
+  if (fileOff < mLen)
+    return *((std::uint8_t *)mBasePtr + fileOff);
+  return 0;
 }
 
 

--- a/extractor/mem-dump.h
+++ b/extractor/mem-dump.h
@@ -9,6 +9,7 @@
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <unistd.h>
+#include <cstdint>
 
 /*******************************************************************************
  *
@@ -17,9 +18,10 @@ class MemDump {
   int           mFd;
   void *        mBasePtr;
   std::uint64_t mLen;
+  std::uint64_t mPhysOffset;
   
 public:
-  MemDump(const char *);
+  MemDump(const char *, std::uint64_t physOffset = 0);
   
   ~MemDump();
   

--- a/extractor/page-dir.cpp
+++ b/extractor/page-dir.cpp
@@ -1,4 +1,5 @@
 #include "page-dir.h"
+#include "common.h"
 
 /*******************************************************************************
  *
@@ -59,6 +60,7 @@ PageDir::constructTrans()
     if (flagSmall == 0x00 && flagLarge == 0x01) {
       std::uint64_t addrHuge = addrLarge >> 4;
       std::uint64_t nPhyAddr = addrHuge << 12;
+      nPhyAddr += vgpuOffset;
       
       std::uint8_t flagHuge = mMemDump.getByte(offsetLarge);
       Trans *next = new Page(mMemDump, nPhyAddr, HUGE, flagHuge);
@@ -72,6 +74,7 @@ PageDir::constructTrans()
     // construct PT for SMALL pages 
     if (flagSmall == 0x02) {      
       std::uint64_t nPhyAddr = addrSmall << 12;      
+      nPhyAddr += vgpuOffset;
       nextSmall = new PageTab(mMemDump, nPhyAddr, PT, SMALL);
       bool ok = nextSmall->constructTrans();
       if (!ok) {
@@ -83,6 +86,7 @@ PageDir::constructTrans()
     // construct PT for LARGE pages 
     if (flagLarge == 0x02) {
       std::uint64_t nPhyAddr = addrLarge << 8;      
+      nPhyAddr += vgpuOffset;
       nextLarge = new PageTab(mMemDump, nPhyAddr, PT, LARGE);
       bool ok = nextLarge->constructTrans();
       if (!ok) {

--- a/extractor/page-map.cpp
+++ b/extractor/page-map.cpp
@@ -1,4 +1,5 @@
 #include "page-map.h"
+#include "common.h"
 
 /*******************************************************************************
  *
@@ -56,6 +57,7 @@ PageMap::constructTrans()
     TransType nTransType = mTransType == PD3 ? PD2 : 
                            mTransType == PD2 ? PD1 : PD0;
     std::uint64_t nPhyAddr = addr << 12;
+    nPhyAddr += vgpuOffset;
     
     Trans *next = nullptr;
     if (nTransType == PD0)

--- a/extractor/page-map.cpp
+++ b/extractor/page-map.cpp
@@ -24,7 +24,7 @@ PageMap::constructTrans()
 {
   // PD3 has 4 entries, but PD2 and PD1 has 512 entries
   int entNum = mTransType == PD3 ? 4 : 512;
-  int entSize = 4096 / entNum;
+  int entSize = 8;
   
   for (int i = 0; i < entNum; ++i) {
     std::uint64_t offset = mPhyAddr + i * entSize;
@@ -43,7 +43,7 @@ PageMap::constructTrans()
     }
     addr &= 0x0000000FFFFFFFFF;
     addr >>= 8;
-    
+
     std::uint8_t flag = mMemDump.getByte(offset);
     flag &= 0x07;
     
@@ -51,7 +51,7 @@ PageMap::constructTrans()
       continue;
     else if (flag != 0x02)
       continue;
-    
+
     // construct the next-level trans
     TransType nTransType = mTransType == PD3 ? PD2 : 
                            mTransType == PD2 ? PD1 : PD0;

--- a/extractor/page-tab.cpp
+++ b/extractor/page-tab.cpp
@@ -1,4 +1,5 @@
 #include "page-tab.h"
+#include "common.h"
 
 /*******************************************************************************
  *
@@ -45,6 +46,7 @@ PageTab::constructTrans()
       return false;
     
     std::uint64_t nPhyAddr = addr << 12;
+    nPhyAddr += vgpuOffset;
     
     Trans *next = new Page(mMemDump, nPhyAddr, mPageType, flagRaw);
     mPageTabEnts[i] = next;


### PR DESCRIPTION
Hello,
I’ve added support for non‑zero starting offsets in the dumper, so that you can now extract page tables from any physical base address. This is especially useful when running multiple GPU instances (MIG). On my A30 with two GPU Instances (GIs), GI 1’s memory begins at 0x2f8000000. Now I can run:

```
extractor dump.bin 0x2f8000000
```

and the extractor will automatically subtract that base address when computing internal addresses.

I’ve also reduced the entry size in page-map.cpp to 8, which gives a noticeable speed‑up during extraction, not sure if it is completely correct.